### PR TITLE
Fixes power of 2 sized enums.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,10 @@ impl <T : EnumSetType> EnumSet<T> {
         self.__enumset_underlying & mask == mask
     }
     fn all_bits() -> T::Repr {
-        (T::ONE << T::VARIANT_COUNT) - T::ONE
+        match T::VARIANT_COUNT {
+            128|64|32|16|8 => T::repr_from_u128(0xFFFFFFFFu128),
+            _ => (T::ONE << T::VARIANT_COUNT) - T::ONE
+        }
     }
 
     /// Returns an empty set.
@@ -681,6 +684,20 @@ mod test {
             pub enum Enum2 {
                 A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
             }
+            pub enum Enum8 {
+                A, B, C, D, E, F, G, H,
+            }
+            pub enum Enum128 {
+                A, B, C, D, E, F, G, H, _8, _9, _10, _11, _12, _13, _14, _15,
+                _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31,
+                _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47,
+                _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63,
+                _64, _65, _66, _67, _68, _69, _70, _71, _72, _73, _74, _75, _76, _77, _78, _79,
+                _80, _81, _82, _83, _84, _85, _86, _87, _88, _89, _90, _91, _92, _93, _94, _95,
+                _96, _97, _98, _99, _100, _101, _102, _103, _104, _105, _106, _107, _108, _109,
+                _110, _111, _112, _113, _114, _115, _116, _117, _118, _119, _120, _121, _122, _123,
+                _124,  _125, _126, _127,
+            }
         }
 
         enum_set_type! {
@@ -743,13 +760,13 @@ mod test {
             mod $m {
                 use super::*;
 
-                const CONST_SET: EnumSet<$e> = enum_set!($e, $e::A | $e::Y);
+                const CONST_SET: EnumSet<$e> = enum_set!($e, $e::A | $e::C);
                 const EMPTY_SET: EnumSet<$e> = enum_set!();
                 #[test]
                 fn const_set() {
                     assert_eq!(CONST_SET.len(), 2);
                     assert!(CONST_SET.contains($e::A));
-                    assert!(CONST_SET.contains($e::Y));
+                    assert!(CONST_SET.contains($e::C));
                     assert!(EMPTY_SET.is_empty());
                 }
 
@@ -813,7 +830,7 @@ mod test {
 
                 #[test]
                 fn debug_impl() {
-                    assert_eq!(format!("{:?}", $e::A | $e::B | $e::W), "EnumSet(A | B | W)");
+                    assert_eq!(format!("{:?}", $e::A | $e::B | $e::D), "EnumSet(A | B | D)");
                 }
 
                 #[test]
@@ -833,4 +850,6 @@ mod test {
 
     test_enum!(Enum, small_enum);
     test_enum!(LargeEnum, large_enum);
+    test_enum!(Enum8, enum8);
+    test_enum!(Enum128, enum128);
 }


### PR DESCRIPTION
Fixes all() and complement() for enums whose variant counts matched the underlying storage size.

There's probably a way to express all_bits as a macro generated constant expression in order to avoid the runtime conditional, but my macro-fu isn't strong enough to figure that out.