### PR TITLE
Implement ExactSizeIterator for EnumSetIter

### DIFF
--- a/enumset/src/lib.rs
+++ b/enumset/src/lib.rs
@@ -649,6 +649,8 @@ impl <T: EnumSetType> Iterator for EnumSetIter<T> {
     }
 }
 
+impl<T: EnumSetType> ExactSizeIterator for EnumSetIter<T> {}
+
 impl<T: EnumSetType> Extend<T> for EnumSet<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         iter.into_iter().for_each(|v| { self.insert(v); });

--- a/enumset/tests/ops.rs
+++ b/enumset/tests/ops.rs
@@ -196,9 +196,11 @@ macro_rules! test_enum {
             let mut itr = set.iter();
             for idx in 0 .. count {
                 assert_eq!(itr.size_hint(), (count-idx, Some(count-idx)));
+                assert_eq!(itr.len(), count-idx);
                 assert!(itr.next().is_some());
             }
             assert_eq!(itr.size_hint(), (0, Some(0)));
+            assert_eq!(itr.len(), 0);
         }
         #[test]
         fn test_iter_size_hint() {


### PR DESCRIPTION
Since the size of an `EnumSetIter` is always known, `ExactSizeIterator` can also be implemented.