### PR TITLE
Add #[repr(transparent)]

### DIFF
--- a/enumset/src/lib.rs
+++ b/enumset/src/lib.rs
@@ -213,6 +213,7 @@ pub unsafe trait EnumSetType: Copy + Eq + EnumSetTypePrivate { }
 /// instead serialized as a list of enum variants. This requires your enum type implement
 /// [`Serialize`] and [`Deserialize`]. Note that this is a breaking change
 #[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct EnumSet<T: EnumSetType> {
     #[doc(hidden)]
     /// This is public due to the [`enum_set!`] macro.


### PR DESCRIPTION
I want use EnumSet in `extern "C" fn` but it can't without this attribute and I also think `transparent` is suitable for this type's purpose