### PR TITLE
Use trailing zeros count for iteration

### DIFF
--- a/enumset/src/repr.rs
+++ b/enumset/src/repr.rs
@@ -30,6 +30,7 @@ pub trait EnumSetTypeRepr :
     fn count_ones(&self) -> u32;
     fn count_remaining_ones(&self, cursor: u32) -> usize;
     fn leading_zeros(&self) -> u32;
+    fn trailing_zeros(&self) -> u32;
 
     fn and_not(&self, other: Self) -> Self;
 
@@ -81,6 +82,7 @@ macro_rules! prim {
 
             fn count_ones(&self) -> u32 { (*self).count_ones() }
             fn leading_zeros(&self) -> u32 { (*self).leading_zeros() }
+            fn trailing_zeros(&self) -> u32 { (*self).trailing_zeros() }
 
             fn and_not(&self, other: Self) -> Self { (*self) & !other }
 


### PR DESCRIPTION
The primary benefit of this change is that it makes the overhead of iterating over the contents of an enum set proportional to its size, rather than the bit width of the set. This is a significant improvement for low-occupancy sets.

* For full enum sets, I saw a change in runtime of +10% to +25% depending on the bit width of the set.
* For half-full enum sets, I saw a change in runtime of -25% to -40% depending on the bit width of the set.
* For single element and empty sets, I saw a change in runtime of -50% to -99% depending on the bit width of the set. Particularly in the case of sets with large bit widths, the time dropped from hundreds of nanoseconds to single-digit nanoseconds.

The performance improvements are slightly greater when compiled with the `bmi1` target feature, which enables the native trailing zero count instruction. I don't have a way to benchmark on non-x86_64 platforms, so I don't know how this affects performance on e.g. ARM.

You can find my benchmarks [here](https://github.com/MinusKelvin/enumset/blob/benchmark/enumset/benches/bench.rs).