### PR TITLE
Allow deriving `EnumSetType` without `Clone + Copy + Eq + PartialEq`

### DIFF
--- a/enumset/src/lib.rs
+++ b/enumset/src/lib.rs
@@ -143,7 +143,12 @@ use crate::repr::EnumSetTypeRepr;
 /// annotation to the enum.
 ///
 /// The custom derive for `EnumSetType` automatically implements [`Copy`], [`Clone`], [`Eq`], and
-/// [`PartialEq`] on the enum. These are required for the [`EnumSet`] to function.
+/// [`PartialEq`] on the enum. These are required for the [`EnumSet`] to function. These automatic
+/// implementations can be disabled by adding an `#[enumset(no_super_impls)]` annotation to
+/// the enum, but they must still be implemented. Disabling the automatic implementations can be
+/// useful if, for example, you are using a code generator that already derives these traits. Note
+/// that the `PartialEq` implementation, if not derived, **must** produce the same results as a
+/// derived implementation would, or else `EnumSet` will not work correctly.
 ///
 /// In addition, if you have renamed the `enumset` crate in your crate, you can use the
 /// `#[enumset(crate_name = "enumset2")]` attribute to tell the custom derive to use that name

--- a/enumset/tests/ops.rs
+++ b/enumset/tests/ops.rs
@@ -15,6 +15,11 @@ pub enum Enum1 {
 pub enum SmallEnum {
     A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
 }
+#[derive(Clone, Copy, Debug, EnumSetType, Eq, PartialEq)]
+#[enumset(no_super_impls)]
+pub enum SmallEnumExplicitDerive {
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+}
 #[derive(EnumSetType, Debug)]
 pub enum LargeEnum {
     _00,  _01,  _02,  _03,  _04,  _05,  _06,  _07,
@@ -84,6 +89,9 @@ macro_rules! test_variants {
     }
 }
 test_variants! { SmallEnum small_enum_all_empty
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+}
+test_variants! { SmallEnumExplicitDerive small_enum_explicit_derive_all_empty
     A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
 }
 test_variants! { LargeEnum large_enum_all_empty
@@ -317,10 +325,10 @@ macro_rules! test_enum {
                     assert!(!$set.contains(&SET_TEST_E));
                 }}
             }
-            
+
             let mut hash_set = HashSet::new();
             test_set!(hash_set);
-            
+
             let mut tree_set = BTreeSet::new();
             test_set!(tree_set);
         }
@@ -353,6 +361,7 @@ macro_rules! tests {
 }
 
 tests!(small_enum, test_enum!(SmallEnum, 4));
+tests!(small_enum_explicit_derive, test_enum!(SmallEnumExplicitDerive, 4));
 tests!(large_enum, test_enum!(LargeEnum, 16));
 tests!(enum8, test_enum!(Enum8, 1));
 tests!(enum128, test_enum!(Enum128, 16));


### PR DESCRIPTION
This PR adds a derive attribute `#[enumset(no_super_impls)]`. When this is used, deriving `EnumSetType` does not also implement `Clone`, `Copy`, `Eq`, or `PartialEq`. These traits must then be implemented some other way instead.

My use case is deriving `EnumSetType` for an enum generated by the [`prost`](https://github.com/tokio-rs/prost) crate, which allows extra derives to be added but always derives `Clone`, `Copy`, `Eq`, or `PartialEq` (among others). Without this `no_super_impls` option, this results in a compile error due to conflicting implementations of these traits.

---

[I had also tried](https://github.com/ahcodedthat/enumset/commit/41fc3d995ab47da1bff5eea3c75fe91b06251fda) simply dropping the `Copy + Eq` requirement entirely, but that turned out to be impossible because:

1. `#[derive(Eq)]` on `EnumSet<T>` sets a bound of `T: Eq` on the generated `Eq` implementation (and likewise for `PartialEq`). Therefore, `Eq` and `PartialEq` must be implemented manually on `EnumSet`. [This problem probably won't be solved any time soon.](https://github.com/rust-lang/rust/issues/26925)
2. `EnumSet` constants cannot be used in patterns if they use a non-derived `Eq` implementation:

```
error: to use a constant of type `enumset::EnumSet` in a pattern, `enumset::EnumSet` must be annotated with `#[derive(PartialEq, Eq)]`
   --> enumset/tests/ops.rs:286:17
    |
286 |                 CONST_SET => { /* ok */ }
    |                 ^^^^^^^^^
```

😞