### PR TITLE
extern alloc only when 'alloc' feature is enabled

### DIFF
--- a/enumset/src/lib.rs
+++ b/enumset/src/lib.rs
@@ -82,6 +82,7 @@
 //! assert_eq!(set, Enum::A | Enum::E | Enum::G);
 //! ```
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod macros;


### PR DESCRIPTION
I currently use this in a `no_std` environment. The latest version bump broke my builds with the following error

```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait
```

Looking at this crate, I noticed that there was an `alloc` feature added. I think a `#[cfg(feature = "alloc")]` was missing where `extern crate alloc` was added.

Let me know if I'm missing something, though. Thank you!