### PR TITLE
add a blanket implementation of Display for EnumSet<T> when T implements Display

### DIFF
--- a/enumset/src/set.rs
+++ b/enumset/src/set.rs
@@ -853,4 +853,23 @@ impl<'a, T: EnumSetType> Sum<&'a T> for EnumSet<T> {
         iter.fold(EnumSet::empty(), |a, v| a | *v)
     }
 }
+
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+impl<T> core::fmt::Display for EnumSet<T>
+where
+    T: core::fmt::Display + EnumSetType,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f,"(")?;
+        for (idx, item) in self.iter().enumerate() {
+            write!(f, "{}", item)?;
+            if idx != self.len() - 1 {
+                write!(f, " | ")?;
+            }
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
 //endregion

--- a/enumset/tests/ops.rs
+++ b/enumset/tests/ops.rs
@@ -528,3 +528,30 @@ bits_tests!(test_u128_bits, U128, (), u128,
 bits_tests!(test_usize_bits, U32, (U128), usize,
             as_usize try_as_usize as_usize_truncated
             from_usize try_from_usize from_usize_truncated);
+
+#[cfg(all(feature = "alloc", test))]
+mod alloc_tests {
+    use super::*;
+    #[derive(EnumSetType, Debug)]
+    pub enum DisplayEnum {
+        A, B, C, D
+    }
+    
+    impl core::fmt::Display for DisplayEnum {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", match self {
+                DisplayEnum::A => "A",
+                DisplayEnum::B => "B",
+                DisplayEnum::C => "C",
+                DisplayEnum::D => "D",
+            })?;
+            Ok(())
+        }
+    }
+    
+    #[test]
+    fn test_display() {
+        let target = DisplayEnum::A | DisplayEnum::B | DisplayEnum::D;
+        assert_eq!(format!("{}", target), "(A | B | D)");
+    }
+}


### PR DESCRIPTION
I wanted this for myself and I think this display impl is general enough to be useful built-in? 

```rust
#[derive(EnumSetType, Debug)]
pub enum DisplayEnum {
    A, B, C, D
}

impl core::fmt::Display for DisplayEnum {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "{}", match self {
            DisplayEnum::A => "A",
            DisplayEnum::B => "B",
            DisplayEnum::C => "C",
            DisplayEnum::D => "D",
        })?;
        Ok(())
    }
}

#[test]
fn test_display() {
let target = DisplayEnum::A | DisplayEnum::B | DisplayEnum::D;
    assert_eq!(format!("{}", target), "(A | B | D)");
}
```