### PR TITLE
Mark `EnumSet::as_repr` as const

### DIFF
--- a/enumset/src/set.rs
+++ b/enumset/src/set.rs
@@ -467,7 +467,7 @@ impl<T: EnumSetType + EnumSetTypeWithRepr> EnumSet<T> {
     /// In order to use this method, the definition of `T` must have the `#[enumset(repr = "…")]`
     /// annotation.
     #[inline(always)]
-    pub fn as_repr(&self) -> <T as EnumSetTypeWithRepr>::Repr {
+    pub const fn as_repr(&self) -> <T as EnumSetTypeWithRepr>::Repr {
         self.__priv_repr
     }
 

--- a/enumset/tests/repr.rs
+++ b/enumset/tests/repr.rs
@@ -5,8 +5,17 @@ use enumset::*;
 #[derive(EnumSetType, Debug)]
 #[enumset(repr = "u16")]
 enum ReprEnum {
-    A, B, C, D, E, F, G, H,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
 }
+
+const _: () = assert!(EnumSet::<ReprEnum>::all().as_repr() == 0b11111111);
 
 #[test]
 fn test() {
@@ -15,10 +24,7 @@ fn test() {
     set.insert(ReprEnum::F);
 
     let repr: u16 = set.as_repr();
-    assert_eq!(
-        (1 << 1) | (1 << 5),
-        repr,
-    );
+    assert_eq!((1 << 1) | (1 << 5), repr,);
 
     let set2 = unsafe { EnumSet::<ReprEnum>::from_repr_unchecked(repr) };
     assert_eq!(set, set2);


### PR DESCRIPTION
This allows it to be used at compile time, along with `EnumSet::all`. This is useful for making static guarantees about the bits in the set.