### PR TITLE
Add basic support for Diesel ORM

### DIFF
--- a/enumset/Cargo.toml
+++ b/enumset/Cargo.toml
@@ -21,6 +21,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 serde = ["serde2", "enumset_derive/serde"]
+diesel = ["dep:diesel", "enumset_derive/diesel"]
 alloc = []
 proc-macro-crate = ["enumset_derive/proc-macro-crate"]
 

--- a/enumset/Cargo.toml
+++ b/enumset/Cargo.toml
@@ -34,6 +34,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 enumset_derive = { version = "0.10.0", path = "../enumset_derive" }
 serde2 = { package = "serde", version = "1", default-features = false, optional = true }
+diesel = { version = "2", optional = true }
 
 [dev-dependencies]
 bincode = { version = "1", features = ["i128"] }

--- a/enumset/src/set.rs
+++ b/enumset/src/set.rs
@@ -470,10 +470,16 @@ where
 {
     fn from_sql(bytes: DB::RawValue<'_>) -> diesel::deserialize::Result<Self> {
         let val = i32::from_sql(bytes)?;
-        Self::try_from_repr(val as u32).ok_or_else(|| {
-            diesel::result::Error::DeserializationError("Bitset contains invalid variants.".into())
+        if T::DIESEL_TRUNCATE {
+            Ok(Self::from_repr_truncated(val as u32))
+        } else {
+            Self::try_from_repr(val as u32).ok_or_else(|| {
+                diesel::result::Error::DeserializationError(
+                    "Bitset contains invalid variants.".into(),
+                )
                 .into()
-        })
+            })
+        }
     }
 }
 //endregion

--- a/enumset/src/traits.rs
+++ b/enumset/src/traits.rs
@@ -64,4 +64,8 @@ pub unsafe trait EnumSetTypePrivate {
     #[cfg(feature = "serde")]
     fn deserialize<'de, D: serde::Deserializer<'de>>(de: D) -> Result<EnumSet<Self>, D::Error>
     where Self: EnumSetType;
+
+    /// Force conversion `EnumSet` from int while reading from SQL result.
+    #[cfg(feature = "diesel")]
+    const DIESEL_TRUNCATE: bool = false;
 }

--- a/enumset_derive/Cargo.toml
+++ b/enumset_derive/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 
 [features]
 serde = []
+diesel = []
 std_deprecation_warning = []
 
 [dependencies]


### PR DESCRIPTION
`EnumSet` types can be used to represent a columns of tables.

Basic support means that only 32-bit int representation is supported.