### PR TITLE
Fix enum_set!() hygiene.

### DIFF
--- a/enumset/src/macros.rs
+++ b/enumset/src/macros.rs
@@ -42,7 +42,7 @@ pub mod __internal {
 #[macro_export]
 macro_rules! enum_set {
     ($(|)*) => {
-        EnumSet::empty()
+        $crate::EnumSet::empty()
     };
     ($value:path $(|)*) => {
         {

--- a/enumset/tests/ops.rs
+++ b/enumset/tests/ops.rs
@@ -559,3 +559,14 @@ impl Display for Enum8 {
 fn test_display_impl() {
     assert_eq!((Enum8::A | Enum8::D | Enum8::H).to_string(), "A | D | H");
 }
+
+mod tests_without_imports {
+    // This deliberately does not use super::* or crate::*
+
+    // The constants below should compile despite not having EnumSet or enumset
+    // in scope.
+
+    const EMPTY: crate::EnumSet<super::SmallEnum> = crate::enum_set!();
+    const CONST_SET: crate::EnumSet<super::SmallEnum> = crate::enum_set!(super::SmallEnum::A | super::SmallEnum::C);
+    const CONST_1_SET: crate::EnumSet<super::SmallEnum> = crate::enum_set!(super::SmallEnum::A);
+}


### PR DESCRIPTION
The enum_set macro in general seems to work fine without EnumSet in scope, but doesn't work if empty, because it uses the EnumSet name unqualified in that one case.

This commit fixes that and adds a test for it.