### PR TITLE
Lengthen the title, using the word `flags`, to improve discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# enumset
+# enumset -- sets of flags, with each flag as an enum variant
 
 [![Build Status](https://github.com/Lymia/enumset/actions/workflows/test.yml/badge.svg)](https://github.com/Lymia/enumset/actions/workflows/test.yml)
 [![Latest Version](https://img.shields.io/crates/v/enumset.svg)](https://crates.io/crates/enumset)

--- a/enumset/Cargo.toml
+++ b/enumset/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.61"
 
 description = "A library for creating compact sets of enums."
-keywords = ["enum", "bitset"]
+keywords = ["enum", "bitset", "flags"]
 categories = ["data-structures"]
 
 documentation = "https://docs.rs/enumset/"


### PR DESCRIPTION
I am in the market for a crate like this.  I noticed that some of my searches didn't turn up this crate.  In particular "enum flags" on lib.rs.

"Sets" s the right way to think of this of course, but I think many people searching for this will think of flags rather than sets.

I'm not sure if you'll like me proposing to change the title like this.

Also, I've aded it to the keywords in `Cargo.toml`.