### PR TITLE
Allow more general discriminants, especially with `map = "compact"`

### DIFF
--- a/enumset/src/derive.rs
+++ b/enumset/src/derive.rs
@@ -12,8 +12,9 @@ use crate::EnumSet;
 /// Currently, the following limitations apply to what kinds of enums this macro may be used with:
 ///
 /// * The enum must have no data fields in any variant.
-/// * Variant discriminators must be zero or positive.
-/// * No variant may have a discriminator larger than `0xFFFFFFBF`.
+/// * Explicit variant discriminators must be zero or positive and no larger than
+///   `0xFFFFFFBF`(except when `map = "compact"`).
+/// * Each explicit discriminator must be a literal, not more general const expressions.
 ///
 /// # Additional Impls
 ///
@@ -65,7 +66,7 @@ use crate::EnumSet;
 ///   most significant bit of the enumset. This requires an explicit integer representation or else
 ///   compilation will fail.
 /// * `#[enumset(map = "compact")]` maps each enum variant to an unspecified bit in the set. This
-///   allows the library to use less memory than it may otherwise and allows any discrminator
+///   allows the library to use less memory than it may otherwise and allows any discriminator
 ///   values to be used without issue.
 /// * `#[enumset(map = "mask")]` treats each enum variant's discriminator as a mask rather than a
 ///   bit index. Each discriminant must be a power of two, and may be of arbitrary size.

--- a/enumset/tests/bitset_basic_ops.rs
+++ b/enumset/tests/bitset_basic_ops.rs
@@ -197,6 +197,23 @@ pub enum MaskSparseEnum {
     E = 1 << 9, F = 1 << 30, G = 1 << 33, H = 1 << 62,
 }
 
+/// Used to test byte literal discriminants with compact mapping.
+#[derive(EnumSetType, Debug)]
+#[enumset(map = "compact")]
+#[rustfmt::skip]
+#[repr(u8)]
+pub enum CompactByteEnum {
+    A = b'A', B = b'B', C = b'C',D,E,F,G,H
+}
+
+/// Used to test negative discriminants with compact mapping.
+#[derive(EnumSetType, Debug)]
+#[enumset(map = "compact")]
+#[rustfmt::skip]
+pub enum CompactNegativeEnum {
+    A = -1, B = -2, C = -3, D = 0, E,F,G,H
+}
+
 /// Used to test mixed enumsets.
 #[derive(EnumSetType, Debug)]
 #[enumset(repr = "u64")]
@@ -773,6 +790,8 @@ tests!(compact_edge_i32n, test_enum!(CompactEdgeCaseI32N, 2, ordered));
 tests!(compact_edge_i32p, test_enum!(CompactEdgeCaseI32P, 2, ordered));
 tests!(compact_edge_i64n, test_enum!(CompactEdgeCaseI64N, 2, ordered));
 tests!(compact_edge_i64p, test_enum!(CompactEdgeCaseI64P, 2, ordered));
+tests!(compact_byte_enum, test_enum!(CompactByteEnum, 1));
+tests!(compact_negative_enum, test_enum!(CompactNegativeEnum, 1));
 
 #[derive(EnumSetType, Debug)]
 #[rustfmt::skip]

--- a/enumset_derive/src/const_eval.rs
+++ b/enumset_derive/src/const_eval.rs
@@ -23,6 +23,7 @@ pub fn eval_literal(expr: &Expr) -> syn::Result<i64> {
                 Ok(val) => Ok(val),
                 Err(_) => error(expr.span(), "Enum discriminants must fit into `isize`.")?,
             },
+            Lit::Byte(lit_byte) => Ok(lit_byte.value() as i64),
             _ => error(expr.span(), "Expression not supported by enumset.")?,
         },
         Expr::Paren(paren) => eval_literal(&paren.expr),

--- a/enumset_derive/src/plan.rs
+++ b/enumset_derive/src/plan.rs
@@ -447,15 +447,15 @@ impl EnumSetInfo {
 
     /// Maps the enum variants as a compact set.
     fn map_compact(&mut self) {
-        let mut occupied = BTreeSet::new();
-        for i in 0..self.variants.len() {
-            occupied.insert(i as u32);
-        }
-        let variant_len = self.variants.len();
+        let variant_len = self.variants.len() as u32;
+        let mut occupied = (0..variant_len).collect::<BTreeSet<_>>();
+
         for variant in &mut self.variants {
-            if variant.discriminant > 0 && variant.discriminant < variant_len as i64 {
-                variant.variant_bit = variant.discriminant as u32;
-                occupied.remove(&variant.variant_bit);
+            if variant.discriminant >= 0 && variant.discriminant < variant_len as i64 {
+                let bit = variant.discriminant as u32;
+                if occupied.remove(&bit) {
+                    variant.variant_bit = bit;
+                }
             }
         }
         for variant in &mut self.variants {


### PR DESCRIPTION
Adds support for byte literals as discriminants (which are allowed with `#[repr(u8)]`).

Also changes the compact bit mapping to use the `0` discriminant (previously only discriminants in `1..variant_len` .were being used). Even though the docs say that `map = "compact"` "maps each enum variant to an unspecified bit in the set", the bits used are observable, so perhaps this should be considered a breaking change. I'm happy to omit this change or file it as a separate PR if that's preferred.

While clarifying the docs regarding the interaction of explicit discriminants (*discriminator* in the docs) and the `map = "compact"` option, I also added a mention that only literal discriminants are supported by the derive macro. I guess this could also be a separate PR but seems quite trivial for that.

Not quite sure why the negative discriminant case seems to work without more changes, but the added test passes.

Fixes #81.